### PR TITLE
Update Dockerfile for radare2 version 5.9.8 and adjust dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get install -y \
   libncurses6:i386 \
   libstdc++6:i386 \
   gnupg2 \
+  vim \
   sudo \
   xz-utils \
   python3-pip \
@@ -52,7 +53,8 @@ RUN apt-get install -y \
   meson \
   xxd \
   wget \
-  tmux
+  tmux \
+  unzip
 
 # nodejs
 RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
@@ -105,6 +107,9 @@ RUN r2pm -i r2dec
 # $ r2 frida://"/bin/ls -al"
 # $ r2 frida://device-id/Twitter
 RUN r2pm -i r2frida
+
+# r2ghidra plugin
+RUN r2pm -i r2ghidra r2ghidra-sleigh 
 
 # Cleanup
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,9 @@
 FROM ubuntu:latest
 
 # Label base
-LABEL r2-docker latest
+LABEL r2-docker=latest
 
-ARG R2_TAG=5.6.8
+ARG R2_TAG=5.9.8
 
 # Build and install radare2 on master branch
 RUN DEBIAN_FRONTEND=noninteractive dpkg --add-architecture i386 && apt-get update
@@ -38,15 +38,18 @@ RUN apt-get install -y \
   make \
   glib-2.0 \
   libc6:i386 \
-  libncurses5:i386 \
+  libncurses6:i386 \
   libstdc++6:i386 \
   gnupg2 \
   sudo \
   xz-utils \
   python3-pip \
+  pipx \
   python-is-python3 \
   openssl \
   build-essential \
+  ninja-build \
+  meson \
   xxd \
   wget \
   tmux
@@ -57,7 +60,7 @@ RUN apt-get update
 RUN apt-get install nodejs
 
 # r2pipe
-RUN pip3 install r2pipe && npm install --unsafe-perm -g r2pipe
+RUN pip3 install --break-system-packages r2pipe && npm install --unsafe-perm -g r2pipe
 
 # Build radare2 in a volume to minimize space used by build
 #VOLUME ["/mnt"]
@@ -75,10 +78,11 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 # Initilise base user
 USER r2
 WORKDIR /home/r2
-ENV HOME /home/r2
+ENV HOME=/home/r2
 
 # Setup r2pm
-RUN r2pm init && r2pm update && chown -R r2:r2 /home/r2/.config
+RUN r2pm -U
+# RUN r2pm -U && chown -R r2:r2 /home/r2/.config
 
 # r2dec plugin
 # command pdd
@@ -91,7 +95,7 @@ RUN r2pm init && r2pm update && chown -R r2:r2 /home/r2/.config
 #   r2dec.theme         | defines the color theme to be used on r2dec.
 #   e scr.html          | outputs html data instead of text.
 #   e scr.color         | enables syntax colors.
-RUN r2pm -ci r2dec
+RUN r2pm -i r2dec
 
 # r2frida plugin
 # Forms of use:
@@ -100,7 +104,7 @@ RUN r2pm -ci r2dec
 # $ r2 frida:///bin/ls
 # $ r2 frida://"/bin/ls -al"
 # $ r2 frida://device-id/Twitter
-RUN r2pm -ci r2frida
+RUN r2pm -i r2frida
 
 # Cleanup
 USER root
@@ -112,4 +116,4 @@ COPY .radare2rc /home/r2/.radare2rc
 COPY ./data /home/r2/data
 COPY .tmux.conf ${HOME}/.tmux.conf
 
-ENTRYPOINT bash
+ENTRYPOINT ["bash"]

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ VERSION ?= 'latest'
 R2_VERSION ?= 'master'
 R2_TAG ?= 5.9.8
 work_dir ?= $(shell pwd)
+IMAGE_NAME ?= 'r2-docker'
 
 # This will output the help for each task
 # thanks to https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
@@ -13,10 +14,10 @@ help: ## This help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 build: ## Common way for images building, can be used variables: R2_VERSION ('master'), R2_TAG (5.9.8)
-	docker build -t luckycatalex/r2-frida:${R2_TAG} \
+	docker build -t ${IMAGE_NAME}:${R2_TAG}":${R2_TAG} \
 	--build-arg R2_VERSION=${R2_VERSION} --build-arg R2_TAG=${R2_TAG} \
 	--network=host . -f Dockerfile
 
 run: ## Common way for images runnig, can be used variables: R2_TAG (5.9.8), work_dir (current directory...)
 	sh -c "docker run --network=host --rm -v $(work_dir):/work_dir \
-	-it luckycatalex/r2-frida:${R2_TAG}" /usr/bin/bash; echo "Exit from container"
+	-it ${IMAGE_NAME}:${R2_TAG}":${R2_TAG}" /usr/bin/bash; echo "Exit from container"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+OS ?= 'ubuntu'
+ARCH ?= 'amd64'
+VERSION ?= 'latest'
+R2_VERSION ?= 'master'
+R2_TAG ?= 5.9.8
+work_dir ?= $(shell pwd)
+
+# This will output the help for each task
+# thanks to https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+.PHONY: help
+
+help: ## This help
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+build: ## Common way for images building, can be used variables: R2_VERSION ('master'), R2_TAG (5.9.8)
+	docker build -t luckycatalex/r2-frida:${R2_TAG} \
+	--build-arg R2_VERSION=${R2_VERSION} --build-arg R2_TAG=${R2_TAG} \
+	--network=host . -f Dockerfile
+
+run: ## Common way for images runnig, can be used variables: R2_TAG (5.9.8), work_dir (current directory...)
+	sh -c "docker run --network=host --rm -v $(work_dir):/work_dir \
+	-it luckycatalex/r2-frida:${R2_TAG}" /usr/bin/bash; echo "Exit from container"


### PR DESCRIPTION
The Dockerfile has been updated to use radare2 version 5.9.8, along with necessary dependency adjustments to ensure compatibility and functionality. This includes changes to package versions and installation commands.